### PR TITLE
Added dependencies needed to compile on Fedora 15

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -101,7 +101,10 @@ Install dependencies: TODO only tested with Fedora 14
 ----
 yum install git gtk2-devel gcc-c++ gcc binutils make cmake gtkglextmm gtkglextmm-devel gtkmm*
 ----
-
+For Fedora 15 (tested on x86_64)
+----
+yum install git gtk2-devel gcc-c++ gcc binutils make cmake gtkglextmm gtkglextmm-devel freeglut-devel libusb1-devel intltool gtkmm*
+----
 Install libreprap (from https://github.com/Ralith/libreprap/blob/master/INSTALL):
 ----
 git clone https://github.com/Ralith/libreprap.git


### PR DESCRIPTION
I just finished compiling repsnapper and libreprap on my Fedora 15 x86_64 box.

It was quite simple and straightforward after adding freeglut-devel libusb1-devel intltool to the dependencies.

Jan
