### PR TITLE
Update doc/manual.asciidoc

### DIFF
--- a/doc/manual.asciidoc
+++ b/doc/manual.asciidoc
@@ -62,6 +62,12 @@ Although RepSnapper is not generally tested outside of windows/linux/mac you may
 ==== Ubuntu ====
 =====  Install dependencies =====
 
+Ubuntu 11.10:
+
+----
+sudo apt-get install git-core build-essential intltool libtool libgtkglext1-dev libgtkmm-2.4-dev freeglut3-dev
+----
+
 Ubuntu 11.04:
 ----
 sudo apt-get install git-core build-essential intltool libtool libgtkglext1-dev libgtkmm-2.4-dev libglut3-dev 


### PR DESCRIPTION
hello, after trying to install the new version on ubuntu 11.10
I received an error due to libglut3-dev package (because it is not the new version in the repositories) is needed by the installation freeglut3-dev.
after this procedure everything compiled correctly.

cordially
Daniel Ramos
