### PR TITLE
Add main category "Utility" to desktop file.

### DIFF
--- a/repsnapper.desktop.in
+++ b/repsnapper.desktop.in
@@ -7,5 +7,5 @@ Exec=repsnapper %F_OR_U
 # Icon=repsnapper
 Terminal=false
 Type=Application
-Categories=GTK;Utility;
+Categories=GTK;Utility;Engineering;
 StartupNotify=true


### PR DESCRIPTION
Desktop files category entry needs to have one main category listed there.
According to http://standards.freedesktop.org/menu-spec/1.0/apa.html "Utility"
should fit this program.

Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
