### PR TITLE
Updated softSurfer license statement, according to the author's permissi...

### DIFF
--- a/licensing.txt
+++ b/licensing.txt
@@ -6,9 +6,9 @@ VMMLib is licensed under a revised 3-clause BSD license as detailed in the file 
 arcball.cpp and arcball.h are (C) 1999-2003 Tatewake.com and licensed under the MIT license as noted in the file licenses/MIT.txt
 
 Several functions in slicer/geometry.cpp are licensed as follows:
-	Copyright 2001, softSurfer (www.softsurfer.com)
-	This code may be freely used and modified for any purpose
-	providing that this copyright notice is included with it.
+	Copyright 2001 softSurfer, 2012-13 Dan Sunday
+	This code may be freely used, distributed and modified for any
+	purpose providing that this copyright notice is included with it.
 	SoftSurfer makes no warranty for this code, and cannot be held
 	liable for any real or imagined damage resulting from its use.
 	Users of this code must verify correctness for their application.


### PR DESCRIPTION
Hi,
I've had legal issues (within Fedora) with code licensed as:

```
This code may be freely used and modified...
```

Without explicit permission for distributing the code freely. I've contacted Dan Sunday, author of the code, and I've got his permission to change the license as proposed in this commit.

The e-mail follows:

```
Miro,
    Yes, I am the right person to ask. The website and code is mine alone,
and no one else is or has been involved. SoftSurfer is a registered DBA
name I have been using. However, in the past year, I have rehosted and
refactored the softsurfer.com site to geomalgorithms.com.

Your request is reasonable. For use in RepSnapper, the copyright statement
for any code on my site can now read:

// Copyright 2001 softSurfer, 2012-13 Dan Sunday
// This code may be freely used, distributed and modified for any
// purpose providing that this copyright notice is included with it.
// SoftSurfer makes no warranty for this code, and cannot be held
// liable for any real or imagined damage resulting from its use.
// Users of this code must verify correctness for their application.

I will likely make this wording change on the website.

One small request. If you make any significant modifications to the code
that would improve the code presented on my site, I would appreciate it if
you would send them to me (only if you want to).

Best Wishes,
Dan Sunday
```

Full e-mail including headers can be found at https://github.com/hroncok/RPMAdditionalSources/blob/master/softsurfer-copyright-email.txt
