### PR TITLE
Modify po/POTFILES.in to let "make check" works.

### DIFF
--- a/po/POTFILES.in
+++ b/po/POTFILES.in
@@ -27,10 +27,8 @@ src/ui/progress.cpp
 src/ui/widgets.cpp
 src/ui/view.cpp
 src/printer/printer.cpp
-src/printer/printer2.cpp
-src/printer/printer_iochannel.cpp
-src/printer/printer_libreprap.cpp
-src/printer/reprap_serial.cpp
+src/printer/printer_serial.cpp
+src/printer/threaded_printer_serial.cpp
 src/slicer/clipping.cpp
 src/slicer/infill.cpp
 src/slicer/infill.h


### PR DESCRIPTION
Make check failed due to there are non-exist files and some missing files in po/POTFILES.in. This patch fixes the POTFILES.in to let "make check" works again.

Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
