### PR TITLE
Fix "nawk: not an option: --version" warning when using non BSD awk.

### DIFF
--- a/tools/gitversion.sh.in
+++ b/tools/gitversion.sh.in
@@ -25,9 +25,14 @@ fi
 AWK=@AWK@
 
 FSEQUAL="="
-# test for BSD awk which needs a blackslash:
-if [ "X`${AWK} --version | head -n 1 | grep BSD`" != "X" ] ; then
-    FSEQUAL="\="
+# if the --version argument of awk is supported try and determine
+# if BSD awk is used
+AWK_VERSION=$(${AWK} --version 2>/dev/null)
+if [ $? -ne 0 ] ; then
+	# test for BSD awk which needs a blackslash:
+	if [ "X`$AWK_VERSION  | head -n 1 | grep BSD`" != "X" ] ; then
+	    FSEQUAL="\="
+	fi
 fi
 
 GIT_DIR="${TOPSRCDIR}/.git"


### PR DESCRIPTION
The gitversion script tries to determine wheter to use additional
bakslashes in awk scripts as required by the BSD version of awk. It
does this by invoking awk with the --version argument.

There is a problems with this. The problem is that the --version
argument is not supported by all awk version. This results in confusing
error messages when calling the gitversion script.

This patch checks the return code returned from invoking awk --version
and assumes that if an error code is returned we are not using the BSD
version and don't need additional quoting. If the awk --version command
doesn't return an error code the logic of the script is not modified.

A proper fix for this problem would be to write a small awk script
that tests if the additional quoting is needed. Most probably it
is also possible to remove the need to use awk at all.
