### PR TITLE
Add LIBZIP_CFLAGS in libraries/amf/Makefile.am to fix FTBFS on Debian.

### DIFF
--- a/libraries/amf/Makefile.am
+++ b/libraries/amf/Makefile.am
@@ -4,6 +4,7 @@ libamf_la_CPPFLAGS = \
 	-I$(srcdir) \
 	-I$(top_srcdir)/libraries/amf/amftools-code/include/ \
 	-I$(top_srcdir)/libraries/amf/amftools-code/include/muparser \
+	$(LIBZIP_CFLAGS) \
         $(EXTRA_CFLAGS)
 
 libamf_la_SOURCES = \


### PR DESCRIPTION
Currently Debian ships libzip 0.11.2. Due to multi-arch support, zipconf.h
is inside /usr/lib/<arch>/libzip/include and we must use LIBZIP_CFLAGS
which comes from pkg-config to avoid the build failed.

Signed-off-by: Ying-Chun Liu (PaulLiu) paulliu@debian.org
