### PR TITLE
Fixed temperature updating.

### DIFF
--- a/src/printer/printer.cpp
+++ b/src/printer/printer.cpp
@@ -350,7 +350,7 @@ bool Printer::QueryTemp( void ) {
     temp_timeout.disconnect();
 
   if ( IsConnected() && m_model && m_model->settings.get_boolean("Misc","TempReadingEnabled") ) {
-    Send( "M105" );
+    SendAsync( "M105" );
     waiting_temp = true;
   }
 

--- a/src/printer/threaded_printer_serial.cpp
+++ b/src/printer/threaded_printer_serial.cpp
@@ -429,6 +429,10 @@ unsigned long ThreadedPrinterSerial::GetTotalPrintingLines( void ) {
   return lines;
 }
 
+bool ThreadedPrinterSerial::SendAsync( char const * command) {
+  return command_buffer.Write( command, true );
+}
+
 bool ThreadedPrinterSerial::Send( string command ) {
   return command_buffer.Write( command.c_str(), true );
 }

--- a/src/printer/threaded_printer_serial.h
+++ b/src/printer/threaded_printer_serial.h
@@ -124,6 +124,7 @@ class ThreadedPrinterSerial : protected PrinterSerial
   // Return the ending line of the current print
 
   using PrinterSerial::Send;
+  bool SendAsync( char const * command );
   bool Send( string command );
   // Command may be multiple commands separated by newlines (\n).
   // Such commands are queued atomically.


### PR DESCRIPTION
ThreadedPrinterSerial::Send has different semantics than PrinterSerial::Send, as was not called correctly. Though it could be fixed, the threaded version does behave differently and should not be interchangable with the synchronnous one. I fixed that, but there may be other problems lurking around. 

Also, the bool Send( string command ); should be removed/renamed.

Feel free to reject the pull request if you deem it's necessary to fix it some other way.