### PR TITLE
Custom baud rate setting fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -6,6 +6,8 @@ AC_CONFIG_SRCDIR([src/repsnapper.cpp])
 AC_CONFIG_MACRO_DIR([m4])
 dnl AC_CONFIG_AUX_DIR([config])
 
+AC_CHECK_HEADERS([fcntl.h float.h limits.h memory.h stdlib.h string.h sys/ioctl.h sys/time.h termios.h unistd.h asm/termbits.h])
+
 AM_INIT_AUTOMAKE
 
 m4_ifdef([AM_SILENT_RULES],[AM_SILENT_RULES([yes])])

--- a/src/printer/Makefile.am
+++ b/src/printer/Makefile.am
@@ -13,14 +13,16 @@ SHARED_SRC += \
 	src/printer/printer_serial.cpp \
 	src/printer/thread_buffer.cpp \
 	src/printer/threaded_printer_serial.cpp \
-	src/printer/printer.cpp
+	src/printer/printer.cpp \
+	src/printer/custom_baud.cpp
 
 SHARED_INC += \
 	src/printer/printer_serial.h \
 	src/printer/thread.h \
 	src/printer/thread_buffer.h \
 	src/printer/threaded_printer_serial.h \
-	src/printer/printer.h
+	src/printer/printer.h \
+	src/printer/custom_baud.h
 
 EXTRA_DIST += \
 	src/printer/printer_serial_test.cpp \

--- a/src/printer/custom_baud.cpp
+++ b/src/printer/custom_baud.cpp
@@ -18,7 +18,7 @@ bool set_custom_baudrate(int device_fd, int baudrate) {
     return false;
   }
 
-  options.c_cflag &= CBAUD;
+  options.c_cflag &= ~CBAUD;
   options.c_cflag |= BOTHER;
 
   options.c_ispeed = baudrate;

--- a/src/printer/custom_baud.cpp
+++ b/src/printer/custom_baud.cpp
@@ -9,12 +9,12 @@
 #include <asm/termbits.h>
 #endif
 
-bool set_custom_baudrate(int device_fd, int baudrate) {
+bool set_custom_baudrate( int device_fd, int baudrate ) {
 #if HAVE_ASM_TERMBITS_H
 
   struct termios2 options;
 
-  if (ioctl(device_fd, TCGETS2, &options) < 0) {
+  if ( ioctl( device_fd, TCGETS2, &options ) < 0 ) {
     return false;
   }
 
@@ -24,7 +24,7 @@ bool set_custom_baudrate(int device_fd, int baudrate) {
   options.c_ispeed = baudrate;
   options.c_ospeed = baudrate;
 
-  if (ioctl(device_fd, TCSETS2, &options) < 0) {
+  if ( ioctl( device_fd, TCSETS2, &options ) < 0 ) {
     return false;
   }
 

--- a/src/printer/custom_baud.cpp
+++ b/src/printer/custom_baud.cpp
@@ -1,0 +1,38 @@
+#ifdef HAVE_CONFIG_H
+#include "config.h"
+#endif
+
+#if HAVE_ASM_TERMBITS_H
+#include <cstdlib>
+#include <fcntl.h>
+#include <sys/ioctl.h>
+#include <asm/termbits.h>
+#endif
+
+bool set_custom_baudrate(int device_fd, int baudrate) {
+#if HAVE_ASM_TERMBITS_H
+
+  struct termios2 options;
+
+  if (ioctl(device_fd, TCGETS2, &options) < 0) {
+    return false;
+  }
+
+  options.c_cflag &= CBAUD;
+  options.c_cflag |= BOTHER;
+
+  options.c_ispeed = baudrate;
+  options.c_ospeed = baudrate;
+
+  if (ioctl(device_fd, TCSETS2, &options) < 0) {
+    return false;
+  }
+
+  return true;
+
+#else
+
+  return false;
+
+#endif
+}

--- a/src/printer/custom_baud.h
+++ b/src/printer/custom_baud.h
@@ -1,1 +1,1 @@
-extern bool set_custom_baudrate(int device_fd, int baudrate);
+extern bool set_custom_baudrate( int device_fd, int baudrate );

--- a/src/printer/custom_baud.h
+++ b/src/printer/custom_baud.h
@@ -1,0 +1,1 @@
+extern bool set_custom_baudrate(int device_fd, int baudrate);

--- a/src/printer/printer_serial.cpp
+++ b/src/printer/printer_serial.cpp
@@ -333,7 +333,7 @@ bool PrinterSerial::RawConnect( string device, int baudrate ) {
   attribs.c_lflag |= ICANON;
   attribs.c_cflag |= HUPCL;
 
-  if( tcsetattr(device_fd, TCSANOW, &attribs ) < 0 ) {
+  if( tcsetattr( device_fd, TCSANOW, &attribs ) < 0 ) {
     close( device_fd );
     device_fd = -1;
 
@@ -353,19 +353,19 @@ bool PrinterSerial::RawConnect( string device, int baudrate ) {
 #if HAVE_ASM_TERMBITS_H
   if ( custom_baud ) {
     // non-standard baud rate
-    baudrate_succeeded = set_custom_baudrate(device_fd, speed);
+    baudrate_succeeded = set_custom_baudrate( device_fd, speed );
   } else {
     baudrate_succeeded = cfsetispeed( &attribs, speed ) >= 0 
                       && cfsetospeed( &attribs, speed ) >= 0
-                      && tcsetattr(device_fd, TCSANOW, &attribs )  >= 0;
+                      && tcsetattr( device_fd, TCSANOW, &attribs )  >= 0;
   }
 #else
   baudrate_succeeded = cfsetispeed( &attribs, speed ) >= 0 
                     && cfsetospeed( &attribs, speed ) >= 0
-                    && tcsetattr(device_fd, TCSANOW, &attribs )  >= 0;
+                    && tcsetattr( device_fd, TCSANOW, &attribs )  >= 0;
 #endif
 
-  if ( !baudrate_succeeded ) {
+  if ( ! baudrate_succeeded ) {
     close( device_fd );
     device_fd = -1;
     char err_str[ 256 ];

--- a/src/printer/printer_serial.cpp
+++ b/src/printer/printer_serial.cpp
@@ -349,6 +349,8 @@ bool PrinterSerial::RawConnect( string device, int baudrate ) {
 
   // Set port speed
   bool baudrate_succeeded = false;
+
+#if HAVE_ASM_TERMBITS_H
   if ( custom_baud ) {
     // non-standard baud rate
     baudrate_succeeded = set_custom_baudrate(device_fd, speed);
@@ -357,6 +359,11 @@ bool PrinterSerial::RawConnect( string device, int baudrate ) {
                       && cfsetospeed( &attribs, speed ) >= 0
                       && tcsetattr(device_fd, TCSANOW, &attribs )  >= 0;
   }
+#else
+  baudrate_succeeded = cfsetispeed( &attribs, speed ) >= 0 
+                    && cfsetospeed( &attribs, speed ) >= 0
+                    && tcsetattr(device_fd, TCSANOW, &attribs )  >= 0;
+#endif
 
   if ( !baudrate_succeeded ) {
     close( device_fd );


### PR DESCRIPTION
Turns out setting non-standard baud rates is not straightforward in Linux; this method is lifted out of python-serial and made to look like C++ :)