### PR TITLE
[amf tools] replace abs() with std::abs() for gcc6 compatibility 

### DIFF
--- a/libraries/amf/amftools-code/include/STL_File.h
+++ b/libraries/amf/amftools-code/include/STL_File.h
@@ -89,7 +89,7 @@ public:
 	Vec3D v;
 	int OrigIndex;
 
-	static inline bool IsSoftLessThan(const aWeldVertex& v1, const aWeldVertex& v2){if(abs(v1.v.z - v2.v.z) <= WeldThresh){ if(abs(v1.v.y - v2.v.y) <= WeldThresh){ return v1.v.x < v2.v.x-WeldThresh;}else return (v1.v.y < v2.v.y-WeldThresh);} else return (v1.v.z < v2.v.z-WeldThresh); } //Is less then (generates a "hash" for sorting vertices by z for set
+	static inline bool IsSoftLessThan(const aWeldVertex& v1, const aWeldVertex& v2){if(std::abs(v1.v.z - v2.v.z) <= WeldThresh){ if(std::abs(v1.v.y - v2.v.y) <= WeldThresh){ return v1.v.x < v2.v.x-WeldThresh;}else return (v1.v.y < v2.v.y-WeldThresh);} else return (v1.v.z < v2.v.z-WeldThresh); } //Is less then (generates a "hash" for sorting vertices by z for set
 	static double WeldThresh; //weld threshold for importing from STL
 };
 


### PR DESCRIPTION
Building with GCC 6 fails with "call of overloaded ‘abs(double)’ is ambiguous" - for some reason only on PowerPC and PPC64.

I have reported this upstream at the [AMF Tools forum](https://sourceforge.net/p/amftools/discussion/general/thread/bea6ee53/) (for some reason that SF project does not allow someone to create tickets for it).

This pull request is mostly to make you aware this issue exist within AMF Tools, I'm not sure if you want to maintain a "fork" with different patches for it. Hopefully AMF Tools upstream will catch up on this.