### PR TITLE
workaround for headers mismatch in linux-libc-dev

### DIFF
--- a/src/printer/custom_baud.cpp
+++ b/src/printer/custom_baud.cpp
@@ -6,7 +6,8 @@
 #include <cstdlib>
 #include <fcntl.h>
 #include <sys/ioctl.h>
-#include <asm/termbits.h>
+#include <asm-generic/ioctls.h>
+#include <asm-generic/termbits.h>
 #endif
 
 bool set_custom_baudrate( int device_fd, int baudrate ) {


### PR DESCRIPTION
**Warning:** since the error so far does not seem to be repsnapper's fault, fell free to ignore this pull request.

The headers in linux-libc-dev are different in powerpc/ppc64el compared to other archs, they seems to be missing include clauses to the headers under the asm-generic/ directory.

This patch works around that by explicitly including both headers under asm-generic.

Please note that the include of arm/termbits.h had to be removed because it causes yet another conflict, this time due to the redefinition of types termios and ktermios, which also only affects powerpc/ppc64el.

There is a [bug open against Ubuntu's linux-libc-dev](https://bugs.launchpad.net/ubuntu/+source/linux/+bug/1619446) about the mismatching headers. Should it be fixed this workaround can be safely ignored.

There are both [Debian](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=810907) and [Ubuntu bugs](https://bugs.launchpad.net/debian/+source/repsnapper/+bug/1619100) open for this workaround.