### PR TITLE
Fix FTBFS for glibmm Glib::RefPtr

### DIFF
--- a/src/model.cpp
+++ b/src/model.cpp
@@ -181,7 +181,7 @@ vector<Shape*> Model::ReadShapes(Glib::RefPtr<Gio::File> file,
 				 uint max_triangles)
 {
   vector<Shape*> shapes;
-  if (file==0) return shapes;
+  if (!file) return shapes;
   File sfile(file);
   vector< vector<Triangle> > triangles;
   vector<ustring> shapenames;


### PR DESCRIPTION
Now we can use operator RefPtr::operator bool() to test if it is NULL.
RefPtr::operator== can not work on int.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>