### PR TITLE
configure.ac: fix detection of external clipper library

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -52,7 +52,7 @@ AC_TYPE_SSIZE_T
 dnl check for installed clipperlib newer than 5.1.0 (has PolyNode)
 AC_DEFINE([HAVE_CLIPPERLIB],[0],[Have external clipper])
 CLIPPER_LIBS="libclipper.la"
-AC_LINK_IFELSE([AC_LANG_PROGRAM([#include <polyclipping/clipper.hpp>], [ClipperLib::PolyNode cnode])],
+AC_COMPILE_IFELSE([AC_LANG_PROGRAM([#include <polyclipping/clipper.hpp>], [ClipperLib::PolyNode cnode;])],
     [AC_DEFINE([HAVE_CLIPPERLIB],[1]) CLIPPER_LIBS="-lpolyclipping"],
     [AC_MSG_WARN([libclipper is not installed. Using internal copy.])])
 AC_SUBST(CLIPPER_LIBS)


### PR DESCRIPTION
We should use AC_COMPILE_IFELSE to detect if the clipper library is
installed or not. If we use AC_LINK_IFELSE, it requires a link but
there's no main() and there's no -lpolyclipping assigned for it. So
we should change AC_LINK_IFELSE to AC_COMPILE_IFELSE.

Also we add a missing semicolon in body in this commit.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>