### PR TITLE
Fix appdata XML format and installation path

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -34,7 +34,7 @@ win32extras_DATA = $(WIN32_FILES)
 
 # AppData support
 @INTLTOOL_XML_RULE@
-appdatadir = $(datadir)/appdata
+appdatadir = $(datadir)/metainfo
 appdata_DATA = $(appdata_in_files:.xml.in=.xml)
 appdata_in_files = repsnapper.appdata.xml.in
 EXTRA_DIST += $(appdata_in_files)

--- a/repsnapper.appdata.xml.in
+++ b/repsnapper.appdata.xml.in
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!-- Copyright 2013 Richard Hughes <richard@hughsie.com> -->
-<application>
+<component type="desktop-application">
   <id type="desktop">repsnapper.desktop</id>
   <licence>CC0</licence>
   <name>Repsnapper</name>
@@ -18,4 +18,4 @@
     <screenshot type="default">http://reprap.org/mediawiki/images/6/6b/Repsnapper.png</screenshot>
   </screenshots>
   <url type="homepage">https://github.com/timschmidt/repsnapper</url>
-</application>
+</component>


### PR DESCRIPTION
According to freedesktop.org latest document, the appdata should
not use "application" root node anymore. It should use component
instead. Also they suggested the installation path changes from
/usr/share/appdata to /usr/share/metainfo.

Signed-off-by: Ying-Chun Liu (PaulLiu) <paulliu@debian.org>